### PR TITLE
Some improvements and streamlining.

### DIFF
--- a/s3-backed-ftp/Dockerfile
+++ b/s3-backed-ftp/Dockerfile
@@ -1,7 +1,22 @@
 FROM factual/docker-base
 
-RUN apt-get -y clean
-RUN apt-get -y update && apt-get -y install automake autotools-dev g++ git libcurl4-gnutls-dev libfuse-dev libssl-dev libxml2-dev make pkg-config python3-pip vsftpd openssh-server supervisor
+RUN apt-get -y update && apt-get -y install --no-install-recommends \
+ automake \
+ autotools-dev \
+ g++ \ 
+ git \ 
+ libcurl4-gnutls-dev \
+ libfuse-dev \
+ libssl-dev \
+ libxml2-dev \
+ make \
+ pkg-config \
+ python3-pip \
+ vsftpd \
+ openssh-server \
+ supervisor \
+ && rm -rf /var/lib/apt/lists/*
+ 
 RUN pip3 install awscli
 
 RUN git clone https://github.com/s3fs-fuse/s3fs-fuse.git && \

--- a/s3-backed-ftp/README.md
+++ b/s3-backed-ftp/README.md
@@ -2,41 +2,44 @@
 
 An ftp/sftp server using s3fs to mount an external s3 bucket as ftp/sftp storage.
 
+More info [here](http://cloudacademy.com/blog/s3-ftp-server/).
+
 ## Usage
 
 To run:
 
-1. First replace env.list.example file with a real env.list file with correct variables filled in.
-	- Add users to USERS environment variable
-  	- May also use non-hashed passwords if storing passwords in plaintext is fine.
-  		- Change line ` echo $u | chpasswd -e ` => ` echo $u | chpasswd ` to use plaintext
-	- AWS keys are now fetched from the EC2 instance currently running the docker container  
-	
-2. Build the docker container using:
+1. Replace `env.list.example` file with a real `env.list` file with correct variables filled in.
+    - Add users to `USERS` environment variable. These should be listed in the form `username:hashedpassword`, each separated by a space.
+     - Passwords for those users should be hashed. There are several ways to hash a user password. A common way is to execute a command like the following: `openssl passwd -crypt {your_password}`. Substitute `{your_password}` with the one you want to hash.
+     - You may also use non-hashed passwords if storing passwords in plaintext is fine. To do this, change line ` echo $u | chpasswd -e ` => ` echo $u | chpasswd ` in the `users.sh` file (line #24).
+    - Specify the S3 buckets were the files (`FTP_BUCKET`) and configs (`CONFIG_BUCKET`) will be stored.
+    - If you are running this container inside an AWS EC2 Instance with an assigned IAM_ROLE, then specify its name in the `IAM_ROLE` environment variable.
+    - If you do not have an IAM_ROLE attached to your EC2 Instance or wherever you are running this, then you have to specify the AWS credentials that will be used to access S3. These are the `AWS_ACCESS_KEY_ID` and the `AWS_SECRET_KEY_ID` keys.
 
-	- ``` docker build --rm -t <docker/tag> path/to/dockerfile/folder ```
+2. If you have changed other files aside the `env.list` file, then you have to build the docker container using:
 
-3. Then after building the container, run using:
+    - `docker build --rm -t <docker/tag> path/to/dockerfile/folder`
 
- 	- ``` docker run --rm -p 21:21 -p 222:22 -p 1024-1048:1024-1048 --name <name> --cap-add SYS_ADMIN --device /dev/fuse --env-file env.list  <docker/tag> ```
-	- If you would like the docker to restart after reboot then use:
-    	* ``` docker run --restart=always -p 21:21 -p 222:22 -p 1024-1048:1024-1048 --name <name> --cap-add SYS_ADMIN --device /dev/fuse --env-file env.list <docker/tag> ```
-  	- If env.list file is named differently change accordingly. 
-  	- If you don't want to use the cap-add and device options you could also just use the privileged option instead:
-    	* ``` docker run --rm -p 21:21 -p 222:22 -p 1024-1024:1024-1048 --privileged --env-file env.list <docker/tag> ```
-	
+3. Then after building the container (if necessary), run using:
+
+    - `docker run --rm -p 21:21 -p 222:22 -p 1024-1048:1024-1048 --name <name> --cap-add SYS_ADMIN --device /dev/fuse --env-file env.list  <docker/tag>`
+    - If you would like the docker to restart after reboot then use:
+        * `docker run --restart=always -p 21:21 -p 222:22 -p 1024-1048:1024-1048 --name <name> --cap-add SYS_ADMIN --device /dev/fuse --env-file env.list <docker/tag>`
+    - If `env.list` file is named differently change accordingly.
+    - If you don't want to use the cap-add and device options you could also just use the privileged option instead:
+        * `docker run --rm -p 21:21 -p 222:22 -p 1024-1024:1024-1048 --privileged --env-file env.list <docker/tag>`
+    
 ## Environment Variables
 
-1. ` USERS ` = List of users to add to the ftp/sftp server. Listed in the form username:hashedpassword, each separated by a space
-2. ` FTP_BUCKET ` = S3 bucket where ftp/sftp users data will be stored
-3. ` CONFIG_BUCKET ` = S3 bucket where the config data (env.list file) will be stored 
-4. ` IAM_ROLE ` = name of role account linked to EC2 instance the container is running in
+1. ` USERS ` = List of users to add to the ftp/sftp server. Listed in the form username:hashedpassword, each separated by a space.
+2. ` FTP_BUCKET ` = S3 bucket where ftp/sftp users data will be stored.
+3. ` CONFIG_BUCKET ` = S3 bucket where the config data (env.list file) will be stored.
+4. ` IAM_ROLE ` = name of role account linked to EC2 instance the container is running in.
 
-
-## Optional Environment Variables
+### Optional Environment Variables
 These two environment variables only need to be set if there is no linked IAM role to the EC2 instance.
 
-1. ` AWS_ACCESS_KEY_ID ` = IAM user account access key
-2. ` AWS_SECRET_ACCESS_KEY ` = IAM user account secret access key
+1. ` AWS_ACCESS_KEY_ID ` = IAM user account access key.
+2. ` AWS_SECRET_ACCESS_KEY ` = IAM user account secret access key.
 
-Set theses environment variables and uncomment lines [28-36](./s3-fuse.sh#L28-36), [39](./s3-fuse.sh#L34), and [40](./s3-fuse.sh#L35) from s3-fuse.sh script
+**Enjoy!**

--- a/s3-backed-ftp/users.sh
+++ b/s3-backed-ftp/users.sh
@@ -28,6 +28,12 @@ for u in $USERS; do
     continue
   elif [ -d "$FTP_DIRECTORY/$username" ]; then
     echo "Skipping creation of '$username' directory: already exists"
+
+    # Directory exists but permissions for it have to be setup anyway.
+    chown root:ftpaccess "$FTP_DIRECTORY/$username"
+    chmod 750 "$FTP_DIRECTORY/$username"
+    chown $username:ftpaccess "$FTP_DIRECTORY/$username/files"
+    chmod 750 "$FTP_DIRECTORY/$username/files"
   else
     echo "Creating '$username' directory..."
     


### PR DESCRIPTION
The following changes were made to make the s3-backed-ftp image easier to use and quicker to understand:
1. Optimized Dockerfile's apt-get instructions to reduce image sized. Image sized was reduced in approximately 100 MB.
2. Fixed errors that ocurred when a container was created, stopped and re-run and the folders and files inside the provided FTP_BUCKET were not deleted. Now the containers can be created and re-created again and again and it will work without errors.
3. Added some conditionals that streamline the process of dealing with provided IAM_ROLEs vs. AWS keys. Now it is much more simple to use either one of them.
4. Streamlined readme and added some more detailed instructions on some parts. Removed parts that are no longer applicable.

Tested in different environments and EC2 instances with and without IAM_ROLEs defined. Everything works as expected.
